### PR TITLE
Adds error handling for when there are no plugin dll files

### DIFF
--- a/entrypoint.bash
+++ b/entrypoint.bash
@@ -27,7 +27,7 @@ cat /appdata/space-engineers/SpaceEngineersDedicated/SpaceEngineers-Dedicated.cf
 #configure plugins section in SpaceEngineers-Dedicated.cfg
 #get new plugins string
 
-if [ "$(ls -1 /appdata/space-engineers/Plugins/*.dll | wc -l)" -gt "0" ]; then
+if [ "$(ls -1 /appdata/space-engineers/Plugins/*.dll 2>/dev/null | wc -l)" -gt "0" ]; then
   PLUGINS_STRING=$(ls -1 /appdata/space-engineers/Plugins/*.dll |\
   awk '{ print "<string>" $0 "</string>" }' |\
   tr -d '\n' |\


### PR DESCRIPTION
I have no idea what's up in line 51.
Maybe it's because I'm editing on Linux and the newline is rendered differently.