### PR TITLE
Feature/add support for contained users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 appdata/
+*.bz2

--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ Thank you to:
 
 ### -RECOMENDED- Pull from dockerhub and run with docker-compose
 
-* Create or login as the user you want to run your space engineers server.  Recommended: Use a separate, dedicated, contained user.
+* Open up a command prompt.  Note: You must have sudo access.
+* Create a user and group you want to run your space engineers server ```sudo adduser <username>```.  Note:  You can use an existing user on your system, but it's recommended to use a separate, dedicated user for maximum security.
 * Clone this repo with ```git clone https://github.com/mmmaxwwwell/space-engineers-dedicated-docker-linux.git```.
 * Change directory into the cloned repo with ```cd space-engineers-dedicated-docker-linux```.
-* Run the setup script with ```./setup```.  This will initialize the ./appdata folder, unzip an empty star system from star-system.zip and set the permissions for the docker user to run.
+* Run the setup script with ```./setup <username from step 2>```.  This will initialize the ./appdata folder, unzip an empty star system from star-system.zip and set the permissions for the docker user to run.
 * (Optional) Copy your world data into the space-engineers-dedicated-docker-linux/appdata/space-engineers/config folder
-* Run the start script with ```./start```. This will start the server.
+* If you copied in world data, rerun the ```./setup <username from step 2>``` command to reset the permissions.
+* Login as the user from step 2 and run the start script with ```./start```. This will start the server.
 
 ### Pull and run from dockerhub without docker-compose:
 From this directory run :

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Thank you to:
 * [Devidian](https://github.com/Devidian) for advancing the docker implementation to a working state!
 * @Inflex for 
 * @Tsu, @Aedis, @ebbit, @data, @ReAn, @BloodyIron, @spawnAjak for all around helping when testing and getting this started
-* [@UseAfterFreee](https://github.com/UseAfterFreee), [@woeisme](https:/github.com/woeisme), [@kennethx](https://github.com/kennethx), [@MarkL4YG](https://github.com/MarkL4YG), [@BaIthamel](https://github.com/BaIthamel), [@Tetrino](https://github.com/Tetrino), [@Teacay1](https://github.com/Teacay1), [@Fischchen](https://github.com/Fischchen), [@whodat](https://github.com/whodat), [@msansen](https://github.com/msansen), [@IndexOutOfMJ](https://github.com/IndexOutOfMJ) for opening issues or contributing to an issue conversation that improved the repo.
+* [@UseAfterFreee](https://github.com/UseAfterFreee), [@woeisme](https:/github.com/woeisme), [@kennethx](https://github.com/kennethx), [@MarkL4YG](https://github.com/MarkL4YG), [@BaIthamel](https://github.com/BaIthamel), [@Tetrino](https://github.com/Tetrino), [@Teacay1](https://github.com/Teacay1), [@Fischchen](https://github.com/Fischchen), [@whodat](https://github.com/whodat), [@msansen](https://github.com/msansen), [@IndexOutOfMJ](https://github.com/IndexOutOfMJ), [@Lothsahn](https://github.com/lothsahn) for opening issues or contributing to an issue conversation that improved the repo.
 
 ## Prerequisites:
 * docker
@@ -34,9 +34,12 @@ Thank you to:
 
 ### -RECOMENDED- Pull from dockerhub and run with docker-compose
 
+* Create or login as the user you want to run your space engineers server.  Recommended: Use a separate, dedicated, contained user.
 * Clone this repo with ```git clone https://github.com/mmmaxwwwell/space-engineers-dedicated-docker-linux.git```.
 * Change directory into the cloned repo with ```cd space-engineers-dedicated-docker-linux```.
-* Run the start script with ```./start```. This will initialize the ./appdata folder, unzip an empty star system from star-system.zip and start the server.
+* Run the setup script with ```./setup```.  This will initialize the ./appdata folder, unzip an empty star system from star-system.zip and set the permissions for the docker user to run.
+* (Optional) Copy your world data into the space-engineers-dedicated-docker-linux/appdata/space-engineers/config folder
+* Run the start script with ```./start```. This will start the server.
 
 ### Pull and run from dockerhub without docker-compose:
 From this directory run :

--- a/backup
+++ b/backup
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+DATE=`date +"%Y-%m-%d-%H%M%S"`
+BACKUP_NAME="$DATE-world.tar.bz2"
+tar -cjvf $BACKUP_NAME appdata/space-engineers/config 

--- a/setup
+++ b/setup
@@ -28,6 +28,7 @@ if [ ! -f ./appdata/space-engineers/config/World/Sandbox.sbc ]; then
 fi
 
 #Take ownership of the appdata folder
+sudo chown -R $USERNAME:$USERNAME .
 sudo chown -R 1000:$USERNAME appdata
 
 #Add the user to the docker group, if not already present

--- a/setup
+++ b/setup
@@ -1,15 +1,27 @@
 #!/bin/bash
+
+USERNAME=$1
+if [ "$1" == "" ]; then
+  echo "Usage: setup <username that runs the space engineers server>"
+  exit
+fi
+
+echo "Setting up space engineers for user: $USERNAME"
+
 sudo mkdir -p appdata/space-engineers/bins/SpaceEngineersDedicated
 sudo mkdir -p appdata/space-engineers/bins/steamcmd
 sudo mkdir -p appdata/space-engineers/config/World
 sudo mkdir -p appdata/space-engineers/config/Plugins
 
-#Unzip the empty world
-sudo unzip -n star-system.zip -d ./appdata/space-engineers/config
+#Unzip the empty world if there's not already a world present
+if [ ! -f ./appdata/space-engineers/config/World/Sandbox.sbc ]; then
+    echo "World not found, initalizing empty star system..."
+    sudo unzip -n star-system.zip -d ./appdata/space-engineers/config
+fi
 
 #Take ownership of the appdata folder
-sudo chown -R 1000:$USER appdata
+sudo chown -R 1000:$USERNAME appdata
 
-#Add the current user to the docker group, if not already present
-sudo gpasswd -a $USER docker
+#Add the user to the docker group, if not already present
+sudo gpasswd -a $USERNAME docker
 

--- a/setup
+++ b/setup
@@ -1,0 +1,15 @@
+#!/bin/bash
+sudo mkdir -p appdata/space-engineers/bins/SpaceEngineersDedicated
+sudo mkdir -p appdata/space-engineers/bins/steamcmd
+sudo mkdir -p appdata/space-engineers/config/World
+sudo mkdir -p appdata/space-engineers/config/Plugins
+
+#Unzip the empty world
+sudo unzip -n star-system.zip -d ./appdata/space-engineers/config
+
+#Take ownership of the appdata folder
+sudo chown -R 1000:$USER appdata
+
+#Add the current user to the docker group, if not already present
+sudo gpasswd -a $USER docker
+

--- a/setup
+++ b/setup
@@ -1,10 +1,18 @@
 #!/bin/bash
 
-USERNAME=$1
 if [ "$1" == "" ]; then
   echo "Usage: setup <username that runs the space engineers server>"
   exit
 fi
+
+if id "$1" &>/dev/null; then
+    echo "User $1 found."
+else
+    echo "User $1 not found.  Please enter a valid user or create the user."
+    exit
+fi
+
+USERNAME=$1
 
 echo "Setting up space engineers for user: $USERNAME"
 

--- a/setup
+++ b/setup
@@ -9,6 +9,7 @@ if id "$1" &>/dev/null; then
     echo "User $1 found."
 else
     echo "User $1 not found.  Please enter a valid user or create the user."
+    echo "Example: sudo adduser $1"
     exit
 fi
 

--- a/start
+++ b/start
@@ -1,18 +1,8 @@
 #!/bin/bash
-sudo mkdir -p appdata/space-engineers/bins/SpaceEngineersDedicated
-sudo mkdir -p appdata/space-engineers/bins/steamcmd
-sudo mkdir -p appdata/space-engineers/config/World
-sudo mkdir -p appdata/space-engineers/config/Plugins
 if [ ! -f ./appdata/space-engineers/config/World/Sandbox.sbc ]; then
     echo "World not found, initalizing empty star system..."
-    sudo unzip -n star-system.zip -d ./appdata/space-engineers/config
+    unzip -n star-system.zip -d ./appdata/space-engineers/config
 fi
 
-#container executes server as 1000:1000
-if [ "$(stat -c '%u' appdata)" != "1000" ]; then
-    echo "Setting owner of appdata to UID 1000"
-    sudo chown -R 1000:1000 appdata
-fi
-
-sudo docker-compose up -d 
-sudo docker-compose logs -f
+docker-compose up -d 
+docker-compose logs -f

--- a/stop
+++ b/stop
@@ -1,2 +1,2 @@
 #/bin/bash
-sudo docker-compose stop
+docker-compose stop


### PR DESCRIPTION
Adds support to run as a contained user instead of running docker as root using sudo.

Adds support for a backup command that creates an archive of the world (the server should be stopped first).

Update the instructions to make them clear how to run as an alternate user and setup the docker containers.